### PR TITLE
fixes #56, always overwrites the toolTip if toolTips are enabled

### DIFF
--- a/src/main/java/com/kagof/intellij/plugins/pokeprogress/PokemonProgressBarUi.java
+++ b/src/main/java/com/kagof/intellij/plugins/pokeprogress/PokemonProgressBarUi.java
@@ -203,7 +203,7 @@ public class PokemonProgressBarUi extends BasicProgressBarUI {
     }
 
     private void setToolTipText() {
-        if (addToolTips.get() && StringUtil.isEmptyOrSpaces(progressBar.getToolTipText())) {
+        if (addToolTips.get()) {
             progressBar.setToolTipText(pokemon.getNameWithNumber());
         }
     }


### PR DESCRIPTION
This is a bit of a heavy-handed fix, but I don't think it is harmful to just always overwrite the toolTip if they are enabled.