### PR TITLE
Fix broken unicode text when building on Windows

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,10 @@ intellij {
     version = "2020.1"
 }
 
+tasks.withType<JavaCompile> {
+    options.encoding = "UTF-8"
+}
+
 tasks.getByName<org.jetbrains.intellij.tasks.PublishTask>("publishPlugin") {
     System.getenv("JETBRAINS_REPO_TOKEN")?.let { token(it) }
     System.getenv("PLUGIN_DEPLOYMENT_CHANNEL")?.let { channels(it) }


### PR DESCRIPTION
Before:
![obrazek](https://user-images.githubusercontent.com/3685160/149664849-9c2b6c21-4432-4959-8d1e-72868e2dae14.png)

After:
![obrazek](https://user-images.githubusercontent.com/3685160/149665274-3d1df927-c0be-41e6-bf92-bc865ac528cb.png)

Closes #62.