### PR TITLE
Fix for issue 89: Makes the plugin compatible with Android Studio versions 2023.3.2+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,4 @@ src/main/resources/com/kagof/intellij/plugins/pokeprogress/sprites/*.png
 .idea
 .DS_Store
 *.cscheme.index
+/local.properties

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,15 +1,13 @@
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 import org.jetbrains.intellij.tasks.RunPluginVerifierTask.FailureLevel
 
-val name: String by project
 val changenotesFile: String by project
 val descriptionFile: String by project
 val ideaVersion: String by project
-val javaVersion: String by project
 val pluginVerifierIdeVersions: String by project
 
 plugins {
-    id("org.jetbrains.intellij") version "1.4.0"
+    id("org.jetbrains.intellij") version "1.17.3" // Use the latest version
     java
 }
 
@@ -31,8 +29,8 @@ intellij {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 tasks {
@@ -58,9 +56,9 @@ tasks {
                 if (dir.exists() && dir.isDirectory && dir.canRead()) {
                     val strb = StringBuilder()
                     dir.listFiles()
-                            ?.filter { it.isFile }
-                            ?.filter { it.name.endsWith(".csv") }
-                            ?.forEach { strb.append(it.name).append("\n") }
+                        ?.filter { it.isFile }
+                        ?.filter { it.name.endsWith(".csv") }
+                        ?.forEach { strb.append(it.name).append("\n") }
                     val index = File(dir, ".cscheme.index")
                     index.delete()
                     index.createNewFile()
@@ -99,7 +97,7 @@ tasks {
     runPluginVerifier {
         ideVersions.set(pluginVerifierIdeVersions.split(",").map { it.trim() }.toList())
         failureLevel.set(listOf(FailureLevel.COMPATIBILITY_PROBLEMS,
-                FailureLevel.NOT_DYNAMIC))
+            FailureLevel.NOT_DYNAMIC))
     }
 
     signPlugin {

--- a/changenotes.html
+++ b/changenotes.html
@@ -1,6 +1,19 @@
 <ul>
     <li>
         <b>
+            <a href="https://github.com/kagof/intellij-pokemon-progress/releases/tag/2.2.0">
+                2.2.0
+            </a>
+        </b>
+        <!--2.2.0-->
+        <ul>
+            <li>Fixes compatibility with Android Studio versions 2023.3.2 and newer</li>
+            <li>Improves plugin initialization to handle IDE startup properly</li>
+        </ul>
+        <!--/2.2.0-->
+    </li>
+    <li>
+        <b>
             <a href="https://github.com/kagof/intellij-pokemon-progress/releases/tag/2.1.1">
                 2.1.1
             </a>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 group=com.kagof
 name=pokemon-progress
-version=2.1.1
+version=2.2.0
 changenotesFile=changenotes.html
 descriptionFile=description.html
 org.gradle.parallel=true
-ideaVersion=2021.1.3
-pluginVerifierIdeVersions=IC-2021.1.3,IC-2021.3.2,IC-2022.1
+ideaVersion=2023.3.2
+pluginVerifierIdeVersions=IC-2021.1.3,IC-2021.3.2,IC-2022.1,IC-2023.3.2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -8,20 +8,22 @@
     <depends>com.intellij.modules.platform</depends>
 
     <extensions defaultExtensionNs="com.intellij">
-        <applicationConfigurable parentId="appearance"
-                                 instance="com.kagof.intellij.plugins.pokeprogress.configuration.PokemonProgressConfigurable"
-                                 id="org.intellij.sdk.settings.AppSettingsConfigurable"
-                                 dynamic="true"
-                                 displayName="Pokémon Progress" />
+        <applicationConfigurable displayName="Pokémon Progress"
+            dynamic="true"
+            id="org.intellij.sdk.settings.AppSettingsConfigurable" instance="com.kagof.intellij.plugins.pokeprogress.configuration.PokemonProgressConfigurable"
+            parentId="appearance" />
         <applicationService
-                serviceImplementation="com.kagof.intellij.plugins.pokeprogress.configuration.PokemonProgressState" />
-        <postStartupActivity implementation="com.kagof.intellij.plugins.pokeprogress.UpdateNotificationActivity" />
-        <notificationGroup id="Pokemon Progress Update" displayType="STICKY_BALLOON" icon="PokeIcons.SpinningPokeball" />
+            serviceImplementation="com.kagof.intellij.plugins.pokeprogress.configuration.PokemonProgressState" />
+        <postStartupActivity
+            implementation="com.kagof.intellij.plugins.pokeprogress.UpdateNotificationActivity" />
+        <postStartupActivity
+            implementation="com.kagof.intellij.plugins.pokeprogress.PokemonProgressListener$PokemonProgressStartupActivity" />
+        <notificationGroup displayType="STICKY_BALLOON" id="Pokemon Progress Update" />
     </extensions>
     <applicationListeners>
         <listener class="com.kagof.intellij.plugins.pokeprogress.PokemonProgressListener"
-                  topic="com.intellij.ide.ui.LafManagerListener" />
+            topic="com.intellij.ide.ui.LafManagerListener" />
         <listener class="com.kagof.intellij.plugins.pokeprogress.PokemonProgressListener"
-                  topic="com.intellij.ide.plugins.DynamicPluginListener" />
+            topic="com.intellij.ide.plugins.DynamicPluginListener" />
     </applicationListeners>
 </idea-plugin>


### PR DESCRIPTION
BE ADVISED:
I am not a plugin developer, nor am I fully aware of any restrictions or guidelines regarding the publication of plugins. Please review and ensure compliance with any relevant rules or requirements.

Fix for issue 89:
This commit addresses compatibility issues with Android Studio versions 2023.3.2 and newer. It also improves plugin initialization to ensure proper functionality after IDE startup.

More specifically:

1. Fixed the initialization issue in PokemonProgressListener:
- Added proper initialization tracking with a static flag
- Added `invokeLater` to ensure UI updates happen on the correct thread
- Added a StartupActivity class to ensure the plugin is properly initialized after IDE startup

2. Updated plugin.xml:
- Added the new StartupActivity to make sure the plugin initializes properly

3. Updated compatibility settings:
- Updated ideaVersion to support newer Android Studio versions (2023.3.2+)
- Updated Java compatibility from Java 11 to Java 17 for newer IDE versions
- Updated plugin version to 2.1.2

4. Added changelog entry:
- Documented the changes in changenotes.html

I did not change the README.md in case you wanted to do it yourself.

The plugin should now work correctly without requiring users to disable and re-enable it in newer Android Studio versions. Please review the changes and feel free to apply any improvements. Your expertise on the matter will offer more than mine.